### PR TITLE
Update routines to write out SOS DC  info to ntuple

### DIFF
--- a/ENGINE/g_keep_results.f
+++ b/ENGINE/g_keep_results.f
@@ -111,6 +111,8 @@
       ENDIF
       ABORT= ABORT .or. FAIL
 *
+*
+      call h_dc_ntuple_keep(ABORT,err)! check for good tracks
 *-COIN
       call C_keep_results(FAIL,why)
       IF(err.NE.' ' .and. why.NE.' ') THEN

--- a/ENGINE/h_dc_ntuple_keep.f
+++ b/ENGINE/h_dc_ntuple_keep.f
@@ -15,6 +15,7 @@
 *
       INCLUDE 'h_dc_ntuple.cmn'
       INCLUDE 'hms_data_structures.cmn'
+      INCLUDE 'sos_data_structures.cmn'
       INCLUDE 'gen_data_structures.cmn'
       INCLUDE 'gen_event_info.cmn'
       INCLUDE 'hms_tracking.cmn'
@@ -55,42 +56,83 @@ c
 * Experiment dependent entries start here.
        evnum=float(gen_event_ID_number)
        evtype= float(gen_event_type)
-       if (evtype .ne. 1) return
+       hdc_ntr=0
+       sdc_ntr=0
+       if (evtype .ne. 2) return
+       if (evtype .eq. 1) then
        do i=1,20
           chi_ind(i)=0
        enddo
-       dc_ntr=HNTRACKS_FP
-       if (dc_ntr .gt.HNTRACKS_MAX) dc_ntr=HNTRACKS_MAX
-       do m=1,dc_ntr
-          dc_xfp(m)=hx_fp(m)
-          dc_xpfp(m)=hxp_fp(m)
-          dc_yfp(m)=hy_fp(m)
-          dc_ypfp(m)=hyp_fp(m)
+       hdc_ntr=HNTRACKS_FP
+       if (hdc_ntr .gt.HNTRACKS_MAX) hdc_ntr=HNTRACKS_MAX
+       do m=1,hdc_ntr
+          hdc_xfp(m)=hx_fp(m)
+          hdc_xpfp(m)=hxp_fp(m)
+          hdc_yfp(m)=hy_fp(m)
+          hdc_ypfp(m)=hyp_fp(m)
        enddo
-       do i=1,dc_ntr
+       do i=1,hdc_ntr
           chimin=10000000.
-          do j=1,dc_ntr
+          do j=1,hdc_ntr
              if ( hchi2_fp(j) .lt. chimin .and. chi_ind(j) .eq.0) then
                 chimin=hchi2_fp(j)
                 endif
              enddo
           found = .false.
-          do j=1,dc_ntr
+          do j=1,hdc_ntr
             if ( hchi2_fp(j) .eq. chimin .and. chi_ind(j) .eq.0 .and. .not. found) then
               chi_ind(j) = i
               found = .true.
               endif
           enddo 
          enddo
-        do i=1,dc_ntr
+        do i=1,hdc_ntr
            m=chi_ind(i)
-          dc_chi2(i)=hchi2_fp(m)
-          dc_xptg(i)=hxp_tar(m)
-          dc_ytg(i)=hy_tar(m)
-          dc_yptg(i)=hyp_tar(m)
-          dc_delta(i)=hdelta_tar(m)
-          dc_ptar(i)=hp_tar(m)
+          hdc_chi2(i)=hchi2_fp(m)
+          hdc_xptg(i)=hxp_tar(m)
+          hdc_ytg(i)=hy_tar(m)
+          hdc_yptg(i)=hyp_tar(m)
+          hdc_delta(i)=hdelta_tar(m)
+          hdc_ptar(i)=hp_tar(m)
           enddo
+       endif
+       if (evtype .eq. 2) then
+       do i=1,20
+          chi_ind(i)=0
+       enddo
+       sdc_ntr=SNTRACKS_FP
+       if (sdc_ntr .gt.SNTRACKS_MAX) sdc_ntr=SNTRACKS_MAX
+       do m=1,sdc_ntr
+          sdc_xfp(m)=sx_fp(m)
+          sdc_xpfp(m)=sxp_fp(m)
+          sdc_yfp(m)=sy_fp(m)
+          sdc_ypfp(m)=syp_fp(m)
+       enddo
+       do i=1,sdc_ntr
+          chimin=10000000.
+          do j=1,sdc_ntr
+             if ( schi2_fp(j) .lt. chimin .and. chi_ind(j) .eq.0) then
+                chimin=schi2_fp(j)
+                endif
+             enddo
+          found = .false.
+          do j=1,sdc_ntr
+            if ( schi2_fp(j) .eq. chimin .and. chi_ind(j) .eq.0 .and. .not. found) then
+              chi_ind(j) = i
+              found = .true.
+              endif
+          enddo 
+         enddo
+        do i=1,sdc_ntr
+           m=chi_ind(i)
+          sdc_chi2(i)=schi2_fp(m)
+          sdc_xptg(i)=sxp_tar(m)
+          sdc_ytg(i)=sy_tar(m)
+          sdc_yptg(i)=syp_tar(m)
+          sdc_delta(i)=sdelta_tar(m)
+          sdc_ptar(i)=sp_tar(m)
+          enddo
+      endif
 * Fill ntuple for this event
       ABORT= .NOT.HEXIST(h_dc_Ntuple_ID)
       IF(ABORT) THEN

--- a/ENGINE/h_dc_ntuple_open.f
+++ b/ENGINE/h_dc_ntuple_open.f
@@ -29,7 +29,8 @@
       character*1000 pat,msg
       integer status,size,io,id,bank,recL,iv(10),m
       real rv(10)
-
+      integer iquest
+       common/quest/iquest(100)
       logical HEXIST           !CERNLIB function
 
 *--------------------------------------------------------
@@ -70,7 +71,8 @@
 
 *-open New *.rzdat file-
       recL= default_recL
-      call HROPEN(io,name,file,'N',recL,status)       !CERNLIB
+      iquest(10)=65000
+      call HROPEN(io,name,file,'NQ',recL,status)       !CERNLIB
 
       ABORT= status.NE.0
       IF(ABORT) THEN
@@ -89,11 +91,16 @@
       call hbset('BSIZE',8176,status)
       call HBNT(id,title,' ')
       call HBNAME(id,'GINFO',evnum,'evnum:R*4,evtype:R*4')
-      call HBNAME(id,'DCINFO',dc_ntr,'dc_ntr[0,20]:I*4,'//
-     >'dc_xfp(dc_ntr):R*4,dc_yfp(dc_ntr):R*4,'//
-     >'dc_xpfp(dc_ntr):R*4,dc_ypfp(dc_ntr):R*4,dc_chi2(dc_ntr):R*4,'//
-     >'dc_ytg(dc_ntr):R*4,dc_xptg(dc_ntr):R*4,'//
-     >'dc_yptg(dc_ntr):R*4,dc_delta(dc_ntr):R*4,dc_ptar(dc_ntr):R*4')
+      call HBNAME(id,'HDCINFO',hdc_ntr,'hdc_ntr[0,20]:I*4,'//
+     >'hdc_xfp(hdc_ntr):R*4,hdc_yfp(hdc_ntr):R*4,'//
+     >'hdc_xpfp(hdc_ntr):R*4,hdc_ypfp(hdc_ntr):R*4,hdc_chi2(hdc_ntr):R*4,'//
+     >'hdc_ytg(hdc_ntr):R*4,hdc_xptg(hdc_ntr):R*4,'//
+     >'hdc_yptg(hdc_ntr):R*4,hdc_delta(hdc_ntr):R*4,hdc_ptar(hdc_ntr):R*4')
+      call HBNAME(id,'SDCINFO',sdc_ntr,'sdc_ntr[0,20]:I*4,'//
+     >'sdc_xfp(sdc_ntr):R*4,sdc_yfp(sdc_ntr):R*4,'//
+     >'sdc_xpfp(sdc_ntr):R*4,sdc_ypfp(sdc_ntr):R*4,sdc_chi2(sdc_ntr):R*4,'//
+     >'sdc_ytg(sdc_ntr):R*4,sdc_xptg(sdc_ntr):R*4,'//
+     >'sdc_yptg(sdc_ntr):R*4,sdc_delta(sdc_ntr):R*4,sdc_ptar(sdc_ntr):R*4')
       call HCDIR(h_dc_Ntuple_directory,'R')      !record Ntuple directory
 
       CALL HCDIR(directory,' ')       !reset CERNLIB directory

--- a/ENGINE/h_keep_results.f
+++ b/ENGINE/h_keep_results.f
@@ -62,8 +62,6 @@
       ENDIF
 *
 *
-      call h_dc_ntuple_keep(ABORT,err)! check for good tracks
-*
       IF(ABORT) THEN
          call G_add_path(here,err)
       ELSE

--- a/INCLUDE/gen_pawspace.cmn
+++ b/INCLUDE/gen_pawspace.cmn
@@ -10,7 +10,7 @@
 *-sizes of CERNLIB working space
 *
       INTEGER G_sizeHBOOK,G_sizeHIGZ,G_sizeKUIP,G_sizePAW
-      PARAMETER (G_sizeHBOOK= 1000000)
+      PARAMETER (G_sizeHBOOK= 8000000)
       PARAMETER (G_sizeHIGZ=   50000)
       PARAMETER (G_sizeKUIP=   75000)
       PARAMETER (G_sizePAW=G_sizeHIGZ+G_sizeKUIP+

--- a/INCLUDE/h_dc_ntuple.cmn
+++ b/INCLUDE/h_dc_ntuple.cmn
@@ -36,10 +36,15 @@
 *
       real*4 evnum,evtype
       common/GINFO/evnum,evtype
-      integer*4 dc_ntr
-      real*4 dc_xfp(20),dc_yfp(20),dc_xpfp(20),dc_ypfp(20),dc_chi2(20)
-      real*4 dc_ytg(20),dc_xptg(20),dc_yptg(20),dc_delta(20),dc_ptar(20)
-      common/DCINFO/dc_ntr,dc_xfp,dc_yfp,dc_xpfp,dc_ypfp,dc_chi2
-     >,dc_ytg,dc_xptg,dc_yptg,dc_delta,dc_ptar
+      integer*4 hdc_ntr
+      real*4 hdc_xfp(20),hdc_yfp(20),hdc_xpfp(20),hdc_ypfp(20),hdc_chi2(20)
+      real*4 hdc_ytg(20),hdc_xptg(20),hdc_yptg(20),hdc_delta(20),hdc_ptar(20)
+      common/HDCINFO/hdc_ntr,hdc_xfp,hdc_yfp,hdc_xpfp,hdc_ypfp,hdc_chi2
+     >,hdc_ytg,hdc_xptg,hdc_yptg,hdc_delta,hdc_ptar
+      integer*4 sdc_ntr
+      real*4 sdc_xfp(20),sdc_yfp(20),sdc_xpfp(20),sdc_ypfp(20),sdc_chi2(20)
+      real*4 sdc_ytg(20),sdc_xptg(20),sdc_yptg(20),sdc_delta(20),sdc_ptar(20)
+      common/SDCINFO/sdc_ntr,sdc_xfp,sdc_yfp,sdc_xpfp,sdc_ypfp,sdc_chi2
+     >,sdc_ytg,sdc_xptg,sdc_yptg,sdc_delta,sdc_ptar
 ****************************end: h_dc_ntuple.cmn ***********************
 


### PR DESCRIPTION
1) Move call h_dc_ntuple_keep to g_keep_results so that it is called for all event types
2) Update h_dc_ntuple_keep
    a) put SOS DC variables into ntuple
    b) have HMS variables start with hdc
    c) hardwire to only write out SOS events (evtype =2)
3) Update h_dc_ntuple_open
    a)  have HMS variables start with hdc
    b)  add SOS DC variables under SDCINFO common block
    c) add iquest(10)=65000 to allow larger ntuple file size
4) In h_keep_results : remove call h_dc_ntuple_keep
5) In gen_pawspace.cmn increase size of G_sizeHBOOK to 8000000
6) Update h_dc_ntuple.cmn
    a)  have HMS variables start with hdc
    b)  add SOS DC variables under SDCINFO common block
