### PR TITLE
Eliminate if (evtype .ne. 2) return

### DIFF
--- a/ENGINE/h_dc_ntuple_keep.f
+++ b/ENGINE/h_dc_ntuple_keep.f
@@ -58,8 +58,8 @@ c
        evtype= float(gen_event_type)
        hdc_ntr=0
        sdc_ntr=0
-       if (evtype .ne. 2) return
-       if (evtype .eq. 1) then
+       if (evtype .gt. 3) return
+       if (evtype .eq. 1 .or. evtype .eq. 3) then
        do i=1,20
           chi_ind(i)=0
        enddo
@@ -96,7 +96,7 @@ c
           hdc_ptar(i)=hp_tar(m)
           enddo
        endif
-       if (evtype .eq. 2) then
+       if (evtype .eq. 2 .or. evtype .eq. 3) then
        do i=1,20
           chi_ind(i)=0
        enddo


### PR DESCRIPTION
1) HMS filled for event type = 1 or 3
2) SOS filled for event type = 2 or 3
3) Return in event type > 3
4) Control event type analysis by command line
  a) Set paramater gtrig2=0 or 1 to turn analysis off/on HMS
  b) Set paramater gtrig3=0 or 1 to turn analysis off/on SOS
  c) Set paramater gtrig4=0 or 1 to turn analysis off/on COIN
