### PR TITLE
Modifications to work on CentOS6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.o
+r_*.f
+O.Linux
+CTP/daVarRpc.h
+CTP/daVarRpc_svc.c
+CTP/daVarRpc_xdr.c
+CTP/daVarRpc_clnt.c
+*~
+*#

--- a/CTP/Makefile.Unix
+++ b/CTP/Makefile.Unix
@@ -76,7 +76,7 @@
 # variable ROOTSYS is undefined, or uncomment "#ROOTSYS=" line below.
 # The same must be done in EXE/Makefile
 
-#ROOTSYS=
+ROOTSYS=
 
 
 NEWSTYLE = 1

--- a/ENGINE/engine.f
+++ b/ENGINE/engine.f
@@ -7,12 +7,15 @@
 *- Loops through data until it encounters an error.
 *-
 *-   Created  18-Nov-1993   Kevin B. Beard, Hampton Univ.
-* $Log$
-* Revision 1.43  2008/09/25 00:06:33  jones
-* Updated to run with gfortran compiler
+* $Log: engine.f,v $
+* Revision 1.41.6.3  2004/07/09 14:12:46  saw
+* Add function calls to fill CTP ROOT Trees
 *
-* Revision 1.42  2004/07/08 20:10:01  saw
-* Close CTP Root trees
+* Revision 1.41.6.2  2004/06/30 19:31:49  cdaq
+* Add call to g_examine_picture_event (DJG)
+*
+* Revision 1.41.6.1  2004/06/18 11:24:11  cdaq
+*  Fixed so that runstats works under Linux
 *
 * Revision 1.41  2004/05/27 23:51:28  jones
 * Initialize EoF = .false.
@@ -284,7 +287,6 @@ c
          If(ABORT) STOP
          err= ' '
       ENDIF
-
       call engine_command_line(.false.) ! Set CTP vars from command line
 *
 * If there is a g_ctp_database_filename set, pass the run number
@@ -417,6 +419,9 @@ c
           else if (gen_event_type.eq.141 .or. gen_event_type.eq.142 .or.
      &             gen_event_type.eq.144) then
 *             write(6,*) 'HV information event, event type=',gen_event_type
+	  else if (gen_event_type.eq.146..or.gen_event_type.eq.147) then
+c	     write(6,*) 'Cheesy poofs! - picture event'
+c	     call g_examine_picture_event
           else if (gen_event_type.eq.251) then
              syncfilter_on = .true.
           else
@@ -488,8 +493,9 @@ c
 * Comment out the following three lines if they cause trouble or
 * if wish is unavailable.
 *
-      write(system_string,*) 'runstats ',file(1:index(file,' ')-1), ' ',
-     $     gen_run_number, '> /dev/null &'
+      write(system_string,*) 
+     >'./runstats ',file(1:index(file,' ')-1), ' ',
+     $     gen_run_number, ' > /dev/null &'
       call system(system_string)
 *
 *-zero entire event buffer
@@ -537,10 +543,10 @@ c Start data analysis
          write(6,*) ' ******'
       endif
 c
+c      write(*,*) ' mkj start do while'
       DO WHILE(.NOT.problems .and. .NOT.ABORT .and. .NOT.EoF)
         mss= ' '
         g_replay_time=time()-start_time
-
         call G_clear_event(ABORT,err)   !clear out old data
         problems= problems .OR. ABORT
 
@@ -555,7 +561,6 @@ c
           problems= problems .OR. ABORT
           if(.NOT.ABORT) total_event_count= total_event_count+1
         EndIf
-
         if(mss.NE.' ' .and. err.NE.' ') then
           call G_append(mss,' & '//err)
         elseif(err.NE.' ') then
@@ -601,7 +606,6 @@ c
             write(6,*) " it is best to do it using the kinematics file"
             write(6,*) " ***********"
           endif
-
           if(jieor(jiand(CRAW(2),'FFFF'x),'10CC'x).eq.0) then ! Physics event
 	    if (gen_event_type.eq.0) then          !scaler event.
               analyzed_events(gen_event_type)=analyzed_events(gen_event_type)+1
@@ -614,7 +618,8 @@ c
              endif            
 c
                if (syncfilter_on) then 
-                 if (  insync .eq. 1 .or.  skip_events ) write(*,*) ' Skipping out-of-sync events'
+                 if (  insync .eq. 1 .or.  skip_events ) 
+     > write(*,*) ' Skipping out-of-sync events'
                  if ( ave_current_bcm(bcm_for_threshold_cut)  .le. g_beam_on_thresh_cur(bcm_for_threshold_cut)
      >  .or. insync .eq. 1 .or. skip_events ) then
                   do ii=1,MAX_NUM_SCALERS
@@ -629,7 +634,8 @@ c
 c
                if (analyzed_events(0) .le. 1 ) then
                   write(*,*) '************'
-                  write(*,*) ' Will not analyze events until after first scaler read'
+                  write(*,*) 
+     > ' Will not analyze events until after first scaler read'
                   write(*,*) '************'
                endif
 *
@@ -645,26 +651,29 @@ c
      &           .and.gen_run_hist_dump_interval.gt.0) then
                 lastdump=physics_events   ! Wait for next interval of dump_int.
                 call g_proper_shutdown(ABORT,err)
-                print 112,"Finished dumping histograms/scalers for first",
+                print 112,
+     >"Finished dumping histograms/scalers for first",
      &             physics_events," events"
  112            format (a,i8,a)
               endif
             else				!REAL physics event.
 c
-               if (analyzed_events(0) .le. 1 .and. gen_event_type .le. 3) then
-                  if (skipped_events_scal .eq. 0 ) then
-                  write(*,*) '************'
-                  write(*,*) ' Will not analyze SOS,HMS or coin events until after first scaler read'
-                  write(*,*) ' Analyzed events :',(analyzed_events(mkj),mkj=1,4)
-                  write(*,*) '************'
-                  endif
+               if (analyzed_events(0) .eq. 0 .and. gen_event_type .le. 3) then
                   skipped_events_scal = skipped_events_scal + 1
                   goto 868      ! kludge mkj
                endif
 c
+                  if (skipped_events_scal .gt. 0 ) then
+                  write(*,*) '************'
+                  write(*,*) ' Will not analyze SOS,HMS or coin"
+     >," events until after first scaler read'
+                  write(*,*) ' Recorded events :',(recorded_events(mkj),mkj=1,3)
+                  write(*,*) ' Analyzed events :',(analyzed_events(mkj),mkj=1,3)
+                  write(*,*) '************'
+                  endif
 c
               if(gen_event_type.le.gen_MAX_trigger_types .and.
-     $           gen_run_enable(gen_event_type-1).ne.0) then
+     $           gen_run_enable(min(gen_event_type,gen_MAX_trigger_types)).ne.0) then
 c
                if ( insync .eq. 1 .and. gen_event_type .le. 3 .and. syncfilter_on ) then
                   skipped_badsync_events(gen_event_type)=skipped_badsync_events(gen_event_type) + 1
@@ -683,16 +692,16 @@ c
                   goto 868
                endif
 c
+
                 call g_examine_physics_event(CRAW,ABORT,err)
                 problems = problems .or.ABORT
-
                 if(mss.NE.' ' .and. err.NE.' ') then
                   call G_append(mss,' & '//err)
                 elseif(err.NE.' ') then
                   mss= err
                 endif
 
-                if (num_events_skipped.lt.gen_run_starting_event .and.
+                if (gen_event_ID_number.lt.(gen_run_starting_event) .and.
      &              gen_event_type.ne.4) then ! always analyze peds.
                   num_events_skipped = num_events_skipped + 1
                 else
@@ -709,6 +718,8 @@ c
                       problems= problems .OR. ABORT
                     else		!gen_event_type=0, scaler event
                     endif
+                  else
+                     write(*,*) ' mkj problem event_type=',gen_event_type
                   endif
 
                   if(mss.NE.' ' .and. err.NE.' ') then
@@ -728,7 +739,8 @@ c
                     start_time=time()     !reset start time for analysis rate
                     groupname='ped'
                   else
-                    write(6,*) 'gen_event_type= ',gen_event_type,' for call to g_keep_results'
+                    write(6,*) 'gen_event_type= '
+     >        ,gen_event_type,' for call to g_keep_results'
                   endif
 
                   If(.NOT.problems .and. groupname.ne.' ') Then
@@ -836,6 +848,7 @@ c
 
         if(gen_run_stopping_event.gt.0 .and. gen_event_ID_number.gt.0) then
           EoF=EoF .or. gen_run_stopping_event.le.sum_analyzed+sum_analyzed_skipped-analyzed_events(4)
+          EoF=EoF .or. gen_run_stopping_event.eq.gen_event_ID_number
         EndIf
 *
 *- Here is where we insert a check for an Remote Proceedure Call (RPC)
@@ -915,14 +928,16 @@ c...
       call G_log_message(mss)
       DO i=1,gen_MAX_trigger_types
         If(recorded_events(i).GT.0) Then
-          write(mss,'(" events of type:",i3," # skipped for bad sync:",i12)')
+          write(mss
+     >,'(" events of type:",i3," # skipped for bad sync:",i12)')
      &             i,skipped_badsync_events(i)
           call G_log_message(mss)
         ENDIF
       ENDDO
       DO i=1,gen_MAX_trigger_types
         If(recorded_events(i).GT.0) Then
-          write(mss,'("  events of type:",i3," # skipped for low current:",i12)')
+          write(mss,
+     >'("  events of type:",i3," # skipped for low current:",i12)')
      &             i,skipped_lowbcm_events(i)
           call G_log_message(mss)
         ENDIF
@@ -942,8 +957,8 @@ c...
       implicit none
       integer iarg
       character*132 arg
-c      integer iargc
-c      external iargc
+c     integer iargc
+c     external iargc
       logical outputflag
 *
 * Process command line args that set CTP variables

--- a/ENGINE/g_decode_config.f
+++ b/ENGINE/g_decode_config.f
@@ -20,7 +20,7 @@
 *
 *     Created  16-NOV-1993   Stephen Wood, CEBAF
 *     Modified  3-Dec-1993   Kevin Beard, Hampton Univ.; rewrote parsing
-* $Log$
+* $Log: g_decode_config.f,v $
 * Revision 1.7  2002/09/25 14:40:33  jones
 *    Add call to G_IO_control to get spareID for unit number to open file
 *     and call at end to G_IO_control free the unit number.
@@ -73,6 +73,7 @@
       integer*4 did, plane, counter, signal, nsubadd, bsubadd
       integer*4 lastroc, lastslot
       integer N_lines_read
+      integer nt,ncomma
 
       logical echo,debug,override
       character*26 lo,HI
@@ -182,9 +183,21 @@
                      endif
                   endif
                else
-
-                  read(line(1:llen),'(4i15)') subadd, plane, counter,
+                  ncomma = 0
+                  do nt=1,llen
+                      if (line(nt:nt) .eq. ',') ncomma=ncomma+1
+                     enddo
+                     if (ncomma .eq. 3) then
+                  read(line(1:llen),*) subadd, plane, counter,
      $                 signal
+                     elseif (ncomma .eq. 2) then
+                  read(line(1:llen),*) subadd, plane, counter
+                     signal=0
+                     else
+                        write(*,*) ' Error in g_decode_config.f '
+                       write(*,*) ' reading line : ', line(1:llen)
+                       stop
+                     endif
                   If(OK .and. (roc.ne.lastroc.or.slot.ne.lastslot)) Then
                      if(g_decode_slotpointer(roc,slot).le.0) then
                         g_decode_slotpointer(roc,slot) =

--- a/ENGINE/g_decode_fb_detector.f
+++ b/ENGINE/g_decode_fb_detector.f
@@ -4,7 +4,7 @@
 *----------------------------------------------------------------------
 *- Created ?   Steve Wood, CEBAF
 *- Corrected  3-Dec-1993 Kevin Beard, Hampton U.
-* $Log$
+* $Log: g_decode_fb_detector.f,v $
 * Revision 1.23  2003/09/05 15:31:23  jones
 * Merge in online03 changes (mkj)
 *
@@ -104,6 +104,7 @@
       integer subaddbit
       logical printerr  !flag to turn off printing of error after 1 time.
       logical firsttime
+      logical plane_test
 *
       integer*4 jishft, jiand, jieor
 *     
@@ -227,7 +228,8 @@ c        if (subadd .lt. '7F'X) then     ! Only valid subaddresses
 *     the sort order is found.
 *     
                 h = hitcount
-                do while(h .gt. 0 .and. (plane .lt. planelist(h)
+                if ( h .gt. 0) then
+                do while((plane .lt. planelist(h)
      $               .or.(plane .eq. planelist(h).and. counter .lt.
      $               counterlist(h))))
 *
@@ -237,8 +239,10 @@ c        if (subadd .lt. '7F'X) then     ! Only valid subaddresses
                   counterlist(h+1) = counterlist(h)
                   signal0(h+1) = signal0(h)
                   h = h - 1
+                  if ( h .eq.0) goto 888
                 enddo
-                h = h + 1               ! Put hit pointer to blank
+                endif
+ 888            h = h + 1       ! Put hit pointer to blank
                 planelist(h) = plane
                 counterlist(h) = counter
                 signal0(h) = signal
@@ -249,17 +253,25 @@ c        if (subadd .lt. '7F'X) then     ! Only valid subaddresses
 *     the same counter or earlier in the sort order is found.
 *     
                 h = hitcount
-                do while(h .gt. 0 .and. (plane .lt. planelist(h)
-     $               .or.(plane .eq. planelist(h).and. counter .lt.
+c                  write(*,*) ' mkj' ,h
+                if ( h .gt.0) then
+                do while( (h .gt. 0) .and. (((h .gt. 0).and.plane .lt. planelist(h))
+     $               .or.( (h .gt. 0).and.plane .eq. planelist(h).and. counter .lt.
      $               counterlist(h))))
                   h = h - 1
+c                  write(*,*) ' mkj' ,h
+                  if (h .le.0) goto878
                 enddo
+                endif
+ 878            continue
 *
 *     If plane/counter match is not found, then need to shift up the array
 *     to make room for the new hit.
 *                
-                if(h.le.0.or.plane.ne.planelist(h) ! Plane and counter
-     $               .or.counter.ne.counterlist(h)) then ! not found
+c                  write(*,*) ' mkj2' ,h
+                plane_test=.false.
+                if ( h .gt.0) plane_test=(plane.ne.planelist(h).or.counter.ne.counterlist(h))
+                if(h.eq.0.or.plane_test) then ! not found
                   if(hitcount.lt.maxhits) then
                     h = h + 1
                     do hshift=hitcount,h,-1 ! Shift up to make room

--- a/ENGINE/g_examine_physics_event.f
+++ b/ENGINE/g_examine_physics_event.f
@@ -10,7 +10,7 @@
 *-         : err                - reason for failure, if any
 *- 
 *-   Created  17-May-1994   Kevin B. Beard, Hampton U.
-* $Log$
+* $Log: g_examine_physics_event.f,v $
 * Revision 1.4  1999/11/04 20:35:16  saw
 * Linux/G77 compatibility fixes
 *
@@ -45,7 +45,8 @@ ccc      LOGICAL process
 *
       integer evtype
       logical eventidbank, nontrivial
-      integer EventIDbank_size,EventIDbank_desc
+      integer EventIDbank_size
+      integer*8 EventIDbank_desc
 *
       integer*4 jiand,jishft,jieor
 *
@@ -64,7 +65,8 @@ ccc      LOGICAL process
 *
       gen_run_total_events= gen_run_total_events+1
       gen_event_type= EvType
-*
+
+*     
       ABORT= EvType.LT.0 .or. EvType.GT.gen_MAX_trigger_types
       If(ABORT) Then
          write(err,'(":illegal physics type #",i3," sequential #",i10)')
@@ -85,7 +87,7 @@ ccc      process= gen_run_enable(EvType)
       If(nontrivial) Then
          EventIDbank= buffer(1).GE.6 .and. 
      &        buffer(3).EQ.EventIDbank_size  
-     &        .and. buffer(4).EQ.EventIDbank_desc
+c     &        .and.  buffer(4).EQ.EventIDbank_desc
 *     
          if(EventIDbank) then
 *

--- a/EXE/Makefile
+++ b/EXE/Makefile
@@ -4,7 +4,7 @@
 # variable ROOTSYS is undefined, or uncomment "#ROOTSYS=" line below.
 # The same must be done in CTP/Makefile.Unix
 
-# ROOTSYS=
+ROOTSYS=
 
 
 disp_objs = glvolu.o 

--- a/INCLUDE/gen_pawspace.cmn
+++ b/INCLUDE/gen_pawspace.cmn
@@ -1,5 +1,5 @@
 **************** begin: gen_pawspace.cmn **********************
-*     $Log$
+*     $Log: gen_pawspace.cmn,v $
 *     Revision 1.2  1994/04/12 20:46:15  cdaq
 *     Increase size of common to 1000000
 *
@@ -10,7 +10,7 @@
 *-sizes of CERNLIB working space
 *
       INTEGER G_sizeHBOOK,G_sizeHIGZ,G_sizeKUIP,G_sizePAW
-      PARAMETER (G_sizeHBOOK= 1000000)
+      PARAMETER (G_sizeHBOOK= 8000000)
       PARAMETER (G_sizeHIGZ=   50000)
       PARAMETER (G_sizeKUIP=   75000)
       PARAMETER (G_sizePAW=G_sizeHIGZ+G_sizeKUIP+

--- a/INCLUDE/hms_cer_parms.cmn
+++ b/INCLUDE/hms_cer_parms.cmn
@@ -1,6 +1,6 @@
 * hms_cer_parms.cmn
 *
-* $Log$
+* $Log: hms_cer_parms.cmn,v $
 * Revision 1.2  2002/12/20 21:52:33  jones
 * Modified by Hamlet for new HMS aerogel
 *
@@ -40,8 +40,8 @@
 *
       real*4 hcer_adc_to_npe(hcer_num_mirrors)
 
-      integer*4 hcer_ped(hcer_num_mirrors)
-      integer*4 hcer_width(hcer_num_mirrors)
+      real*4 hcer_ped(hcer_num_mirrors)
+      real*4 hcer_width(hcer_num_mirrors)
 
       common/hms_cer_trans/
      &   hcer_ped,

--- a/INCLUDE/hms_tracking.cmn
+++ b/INCLUDE/hms_tracking.cmn
@@ -7,7 +7,7 @@
 *                            15 Feb 
 *                            separate dimensioning and number of planes
 *                           and chambers
-* $Log$
+* $Log: hms_tracking.cmn,v $
 * Revision 1.27  2003/04/01 13:55:09  jones
 * Add variables hntracks_max_fp and h_remove_sppt_if_one_y_plane to
 * hms_tracking.cmn
@@ -109,6 +109,8 @@
 *
 *      CTPTYPE=parm
 *
+      integer*4 hdc_fix_lr  !
+      integer*4 hdc_fix_propcorr  !
       integer*4 hdriftbins_max  ! number of bins for drift time lookup table
       parameter (hdriftbins_max=138)
       real*4    hdriftbins         ! number of bins for drift time lookup table
@@ -127,7 +129,7 @@
      $     hfract(hdriftbins_max,hmax_num_dc_planes),
      $     hdriftbinsz,
      $     hdrift1stbin,
-     $     hdriftbins
+     $     hdriftbins,hdc_fix_lr,hdc_fix_propcorr
 
       equivalence (hwc1x1fract(1),hfract(1,1))
       equivalence (hwc1y1fract(1),hfract(1,2))
@@ -150,9 +152,9 @@
       integer*4 hmax_chamber_hits
       parameter (hmax_chamber_hits=544)
       integer*4 hmax_space_points   ! maximum number of space points
-      parameter (hmax_space_points=50)
+      parameter (hmax_space_points=100)
       integer*4 hmax_hits_per_point ! maximum number of hits per point
-      parameter (hmax_hits_per_point=20)
+      parameter (hmax_hits_per_point=100)
       integer*4 hnum_fpray_param    ! number of ray parameters in focal plane
       parameter (hnum_fpray_param=4)
       integer*4 hdc_num_cards       ! #/discriminator cards
@@ -202,6 +204,10 @@
                                    ! (n,1) = number of hits
                                    ! (n,2) = number of valid combinations
                                    ! (n,3...) hit numbers for space point
+      real*4 hspace_point_leftright
+      REAL*4 HDC_DRIFT_TIME_spt
+      real*4 hspace_point_driftdis
+      real*4 hspace_point_wirecoord
       real*4 hspace_points         ! array of x, y of space points
       real*4 hbeststub             ! array of stubs fit to each space point
       real*4 hdc_sing_drifttime    ! array of fully corrected drift times for each plane
@@ -209,16 +215,18 @@
 
 *
       common/HMS_TRACKING/
-     &     hdc_num_chambers,hdc_num_planes,
-     &     hdc_planes_per_chamber,
+     &     hdc_num_chambers,hdc_num_planes,hdc_planes_per_chamber,
      &     hdc_hits_per_plane(hmax_num_dc_planes),
-     &     gplanehdc1(hmax_space_points),
-     &     gplanehdc2(hmax_space_points),
+     &     gplanehdc1(hmax_space_points),gplanehdc2(hmax_space_points),
      &     hspace_points(hmax_space_points,2),
      &     hspace_point_hits(hmax_space_points,hmax_hits_per_point+2),
+     &     hspace_point_leftright(hmax_space_points,hmax_hits_per_point),
+     &     hspace_point_driftdis(hmax_space_points,hmax_hits_per_point),
+     &     hspace_point_wirecoord(hmax_space_points,hmax_hits_per_point),
+     1     HDC_DRIFT_TIME_spt(hmax_space_points,hmax_hits_per_point),
      &     hnspace_points(hmax_num_chambers),
      &     hnspace_points_tot,
-     &     hbeststub(hmax_space_points,hnum_fpray_param),
+     &     hbeststub(hmax_space_points,hnum_fpray_param+2),
      &     hncham_hits(hmax_num_chambers),
      &     htrack_fit_num,
      &     hspace_point_criterion(hmax_num_chambers),
@@ -314,6 +322,10 @@
       integer*4 hdc_didhit(hmax_num_dc_planes,hdc_max_wires_per_plane)
       integer*4 hdc_shouldsum(hmax_num_dc_planes)
       integer*4 hdc_didsum(hmax_num_dc_planes)
+      integer*4 hdc_shouldhit_del(hmax_num_dc_planes,hdc_max_wires_per_plane,20)
+      integer*4 hdc_didhit_del(hmax_num_dc_planes,hdc_max_wires_per_plane,20)
+      integer*4 hdc_shouldsum_del(hmax_num_dc_planes,20)
+      integer*4 hdc_didsum_del(hmax_num_dc_planes,20)
       integer*4 hdc_eff(hmax_num_dc_planes)
       real*4 hdc_track_coord(hntracks_max,hmax_num_dc_planes)
       real*4 hsdc_track_coord(hmax_num_dc_planes)
@@ -325,6 +337,10 @@
      &   hdc_didhit,        !times a wire did fire.
      &   hdc_shouldsum,     !sum over plane.
      &   hdc_didsum,        !sum over plane.
+     &   hdc_shouldhit_del,     !times a wire should have fired.
+     &   hdc_didhit_del,        !times a wire did fire.
+     &   hdc_shouldsum_del,     !sum over plane.
+     &   hdc_didsum_del,        !sum over plane.
      &   hdc_eff,           !effic. per plane.
      &   hdc_min_wire_eff,  !warning level for wire effic.
      &   hdc_min_plane_eff, !warning level for plane effic.
@@ -400,56 +416,36 @@
       integer hslope
       integer hbestxpscin
       integer hbestypscin
-      integer hgoodscinhits
+      integer hgoodscinhits,hgoodscinhits_x(16)
       integer hxloscin(hmax_num_chambers),hxhiscin(hmax_num_chambers)
       integer hyloscin(hmax_num_chambers),hyhiscin(hmax_num_chambers)
       integer htrack_eff_test_num_scin_planes
 
       common/dereks_hms_track_tests/
-     &    h1hit1,
-     &    h1hit2,
-     &    h1hit3,
-     &    h1hit4,
-     &    h1hit5,
-     &    h1hit6,
-     &    h1hit7,
-     &    h1hit8,
-     &    h1hit9,
-     &    h1hit10,
-     &    h1hit11,
-     &    h1hit12,
-     &	  hnumhit1,hnumhit2,hnumhit3,hnumhit4,hnumhit5,hnumhit6,
-     &    hnumhit7,hnumhit8,hnumhit9,hnumhit10,hnumhit11,hnumhit12,
-     &    h1hitslt,
-     &    h2hitslt,
-     &    h1planesgt,
-     &    h2planesgt,
-     &    hhitslt,
-     &    hplanesgt,
-     &    hstublt,
-     &    f1hspacepoints,
-     &    f2hspacepoints,
-     &    fhspacepoints,
-     &    hhitsplanes,
-     &    hhitsplanessps,
-     &    hhitsplanesspsstubs,
-     &    hspacepoints,
-     &    htest1,htest2,
-     &    hfoundtrack,
-     &    hcleantrack,
-     &    hnumhits1,hnumhits2,hnumplanes1,hnumplanes2,
-     &    hnumscins1,hnumscins2,hnumscins3,hnumscins4,
-     &    hstubtest,
-     &    hstubminx,
-     &    hstubminy,
-     &    hstubminxp,
-     &    hstubminyp,
-     &	  hscinhit,
-     &    hnclust,
-     &    hthreescin,
-     &    hslope,
-     &    hbestxpscin,
-     &    hbestypscin,
-     &    hgoodscinhits,
-     &    hxloscin,hxhiscin,hyloscin,hyhiscin,
-     &    htrack_eff_test_num_scin_planes
+     &h1hit1,h1hit2,h1hit3,h1hit4,h1hit5,h1hit6,h1hit7,
+     &h1hit8,h1hit9,h1hit10,h1hit11,h1hit12,
+     &hnumhit1,hnumhit2,hnumhit3,hnumhit4,hnumhit5,hnumhit6,
+     &hnumhit7,hnumhit8,hnumhit9,hnumhit10,hnumhit11,hnumhit12,
+     &h1hitslt,h2hitslt,h1planesgt,h2planesgt,hhitslt,hplanesgt,
+     &hstublt,f1hspacepoints,f2hspacepoints,fhspacepoints,
+     &hhitsplanes,hhitsplanessps,hhitsplanesspsstubs,
+     &hspacepoints,
+     &htest1,htest2,
+     &hfoundtrack,
+     &hcleantrack,
+     &hnumhits1,hnumhits2,hnumplanes1,hnumplanes2,
+     &hnumscins1,hnumscins2,hnumscins3,hnumscins4,
+     &hstubtest,
+     &hstubminx,
+     &hstubminy,
+     &hstubminxp,
+     &hstubminyp,
+     &hscinhit,
+     &hnclust,
+     &hthreescin,
+     &hslope,
+     &hbestxpscin,
+     &hbestypscin,
+     &hgoodscinhits,hgoodscinhits_x,
+     &hxloscin,hxhiscin,hyloscin,hyhiscin,
+     &htrack_eff_test_num_scin_planes

--- a/INCLUDE/sos_tracking.cmn
+++ b/INCLUDE/sos_tracking.cmn
@@ -4,7 +4,7 @@
 *     modified  dfg          10 Feb 94
 *                              change name to sos_tracking.cmn
 *                              put sluno and debugflags from parameters to CTP
-* $Log$
+* $Log: sos_tracking.cmn,v $
 * Revision 1.18  1999/02/23 19:22:52  csa
 * (JRA) Remove sdebugcalcpeds
 *
@@ -120,7 +120,7 @@
       integer*4 smax_space_points   ! maximum number of space points
       parameter (smax_space_points=50)
       integer*4 smax_hits_per_point ! maximum number of hits per point
-      parameter (smax_hits_per_point=15)
+      parameter (smax_hits_per_point=50)
       integer*4 snum_fpray_param    ! number of ray parameters in focal plane
       parameter (snum_fpray_param=4)
       integer*4 sdc_num_cards       ! #/discriminator cards

--- a/UTILSUBS/get_values.f
+++ b/UTILSUBS/get_values.f
@@ -1,6 +1,6 @@
         SUBROUTINE get_values(string,n,values,ok) 
 *
-* $Log$
+* $Log: get_values.f,v $
 * Revision 1.1  1994/02/22 20:00:24  cdaq
 * Initial revision
 *
@@ -18,41 +18,41 @@
         PARAMETER (quote='''')
 c................................................................ 
         n=0
-	orig= string
-        CALL no_tabs(orig)			!remove tabs
-        DO WHILE (INDEX(orig,quote).ne.0)	!remove quote marks 
+        orig= string
+        CALL no_tabs(orig)                      !remove tabs
+        DO WHILE (INDEX(orig,quote).ne.0)       !remove quote marks 
           i=INDEX(orig,quote) 
           orig(i:i)=' ' 
         ENDDO 
-        DO WHILE (INDEX(orig,'::').ne.0) 	!replace sequence marks
+        DO WHILE (INDEX(orig,'::').ne.0)        !replace sequence marks
           i=INDEX(orig,'::') 
           orig(i:i+1)='^ '
         ENDDO 
-        DO WHILE (INDEX(orig,':').ne.0) 	!replace seperator marks
+        DO WHILE (INDEX(orig,':').ne.0)         !replace seperator marks
           i=INDEX(orig,':') 
           orig(i:i)=','
         ENDDO 
-        CALL NO_blanks(orig)			!remove blanks
-	CALL UP_case(ORIG)			!shift to upper case
+        CALL NO_blanks(orig)		        !remove blanks
+        CALL UP_case(ORIG)                      !shift to upper case
         IF(orig.EQ.' ') THEN
-          ok=.false.				!nothing to read
+          ok=.false.                            !nothing to read
           RETURN
         ENDIF 
 c
         line= orig
 	j= INDEX(line,',')
-	IF(j.gt.0) line(j:)=' '		!get first line
+	IF(j.gt.0) line(j:)=' '	                 !get first line
 c
         DO WHILE (orig.NE.' ')
 c
-	  divider= INDEX(line,'*')			!duplicate
-	  If(divider.eq.0) divider= INDEX(line,'^')	!sequence
+	  divider= INDEX(line,'*')                      !duplicate
+	  If(divider.eq.0) divider= INDEX(line,'^')     !sequence
 c
 	  If(divider.eq.0) Then
 		cycle=1
 		this= line
 	  ElseIf(divider.eq.1) Then
-                GOTO 2222 			!illegal
+                GOTO 2222                                !illegal
 	  Else
 		cycle=2
 		this= line(1:divider-1)
@@ -72,12 +72,12 @@ c
               this(last_hex:)=' ' 
               CALL squeeze(this,i)
               IF(this.eq.' ') goto 2222
-              READ(this(1:i),'(z)',err=2222) v(j)
+              READ(this(1:i),'(z1)',err=2222) v(j)
             elseif(oct) then
               this(last_oct:)=' ' 
               CALL squeeze(this,i)
               IF(this.eq.' ') goto 2222
-              READ(this(1:i),'(o)',err=2222) v(j)
+              READ(this(1:i),'(o1)',err=2222) v(j)
             elseif(bin) then
               this(last_binary:)=' '
               CALL squeeze(this,i)
@@ -95,7 +95,7 @@ c
             else
               CALL squeeze(this,i)
               IF(this.eq.' ') goto 2222
-              READ(this(1:i),'(i)',err=2222) v(j)
+              READ(this(1:i),'(i1)',err=2222) v(j)
             endif
 c
 	    this= line(divider+1:)	 

--- a/etc/Makefile.NEW
+++ b/etc/Makefile.NEW
@@ -73,9 +73,11 @@ all:  $(SUBDIRNAME) $(SUBDIRNAME)/Makefile
 $(MAKEFILENAME):
 	@echo change in $(CURDIR)/$(MAKEFILENAME)
 	(cd $(SUBDIRNAME) ; ln -f -s ../$(MAKEFILENAME) Makefile)
+
 $(SUBDIRNAME)/Makefile: $(MAKEFILENAME)
 	@echo copy $(CURDIR)/$(MAKEFILENAME)
-	(cd $(SUBDIRNAME) ; ln -f -s ../$(MAKEFILENAME) Makefile)
+	cp $(CURDIR)/$(MAKEFILENAME) $(CURDIR)/$(SUBDIRNAME)/Makefile
+
 
 $(SUBDIRNAME):
 	mkdir $(SUBDIRNAME)

--- a/etc/Makefile.variables
+++ b/etc/Makefile.variables
@@ -10,8 +10,8 @@ unexport getversion gccversion g77flags message #except these ones
 CFLAGS = -Wall -W -O -ggdb #-pg #-pedantic
 #CFLAGS = -Wall -W
 CXXFLAGS := $(CFLAGS)
-#FFLAGS = -O -ffixed-line-length-132 -ggdb -Wall -W -fbounds-check #-pg #-pedantic
-FFLAGS = -O -ffixed-line-length-132 -ggdb -Wall -W  #-pg #-pedantic
+FFLAGS = -O -ffixed-line-length-132 -ggdb -Wall -W -fbounds-check #-pg #-pedantic
+#FFLAGS = -O -ffixed-line-length-132 -ggdb -Wall -W  #-pg #-pedantic
 CC = gcc
 CXX = g++
 ifeq ($(gccversion),4)


### PR DESCRIPTION
To get to work on CentOS6.2
Modified UTILSUBS/get_values.f to change some format statements
Modified ENGINE/g_decode_config.f to read map file. With new compiler, no longer would read all lines
   with same (4i5) format whether the line had 3 or 4 variables. Had to implement a specific read
  depending if line has 2 or 3 commas.
Modified ENGINE/g_decode_fb_detector.f 
Modified ENGINE/g_examine_physics_event.f   to eliminate check buffer(4).EQ.EventIDbank_desc
   in setting EventIDbank
Modified INCLUDE/hms_tracking.cmn to increase hmax_space_point and hmax_hits_per_point to 100 
  This got rid of segmentation fault in the CTP routines when running the ENGINE.

Additional changes:
Add  .gitignore file
Modify CTP/Makefile.Unix and EXE/Makefile so that it does NOT compile with ROOT tree output.
Modify etc/Makefile.variables so that it compiles with bounds-check flag
Modify etc/Makefile.NEW
Modify INCLUDE/gen_pawspace.cmn so that G_sizeHBOOK =8000000
Modify INCLUDE/sos_tracking.cmn so smax_hits_per_point =50
Modify INCLUDE/hms_cer_parms.cmn so hcer_peds and hcer_width are real instead of integer
Modify ENGINE/engine.f so that gstop and gstart are compared to the event ID number to make it
   easier to compare to hcana. 
