### PR TITLE
Correct assignment of energy to tracks in the HMS.

### DIFF
--- a/HTRACKING/h_clusters_cal.f
+++ b/HTRACKING/h_clusters_cal.f
@@ -21,7 +21,7 @@
 *-      Modified 25 Mar 1994      DFG
 *-                                Change name of print routine
 *                10 Apr 1994      DFG Protect for Et=0 division
-* $Log$
+* $Log: h_clusters_cal.f,v $
 * Revision 1.5  1999/02/03 21:13:23  saw
 * Code for new Shower counter tubes
 *
@@ -204,12 +204,15 @@
         if(hcluster_et(nc).gt.0.) then
           hcluster_xc(nc)=hcluster_xc(nc)/hcluster_et(nc)
         else
-          hcluster_xc(nc)= -1.0         ! Set fraction negative for bad et
+          hcluster_xc(nc)= -999999.         ! Set out of the calorimeter volume
         endif
       enddo
 *
  100  continue
       if(hdbg_clusters_cal.gt.0) call h_prt_cal_clusters
+c
+      write(88,*) hnclusters_cal
+c
 *
       return
       end

--- a/HTRACKING/h_tracks_cal.f
+++ b/HTRACKING/h_tracks_cal.f
@@ -67,8 +67,8 @@
       real*4 delta_x    !Distance between track & cluster in X projection
       logical*4 track_in_fv
 
-      integer*4 t_nt,t_nc
-      real*4 t_minx,temp_x
+      integer*4 t_nc
+      real*4 t_minx
 
       include 'hms_data_structures.cmn'
       include 'hms_calorimeter.cmn'
@@ -113,24 +113,20 @@
         if( (hcal_fv_test.ne.0.and.track_in_fv) .or. hcal_fv_test.eq.0) then
 
           if(hnclusters_cal.gt.0) then
-             t_minx=9
-             t_nt = 1
-             t_nc = 1
+             t_minx=999999.
+             t_nc = -1
             do nc=1,hnclusters_cal
               delta_x=abs(xf-hcluster_xc(nc))
               if(delta_x.le.(0.5*hcal_block_xsize + hcal_slop)) then
-                temp_x = delta_x
-                if(temp_x.lt.t_minx) then
-                   t_minx = temp_x
-                   t_nt = nt
+                if(delta_x.lt.t_minx) then
+                   t_minx = delta_x
                    t_nc = nc
                 endif
-!                hcluster_track(nt)=nc   !Track matches cluster #nc
                 hntracks_cal      =hntracks_cal+1
               endif                     !End ... if matched
             enddo                       !End loop over clusters
 
-                hcluster_track(t_nt)=t_nc   !Track matches cluster #nc with min deviation
+            hcluster_track(nt)=t_nc !Track matches cluster #nc with min deviation
           endif                         !End ... if number of clusters > 0
         endif                           
       enddo                             !End loop over detector tracks


### PR DESCRIPTION
Correct association of clusters of calorimeter hits to tracks in the HMS. Affected subroutines are h_clusters_cal and h_tracks_cal. Clusters with zero energy deposition are eliminated from the association by assigning them a coordinate out of reach of tracks in h_clusters_cal. Linking of the closest to track cluster is corrected and simplified in h_tracks_cal. The corrected code was checked against hcana.
