### PR TITLE
Fix small bugs in calorimeter cluster and track matching routines.

### DIFF
--- a/HTRACKING/h_clusters_cal.f
+++ b/HTRACKING/h_clusters_cal.f
@@ -104,7 +104,8 @@
                   d_col=iabs(jcol-icol)
 *
 *-----------------Are these hits a neighbor to "seed"?
-                  if(d_row.le.1.and.d_col.le.1) then
+                  if((d_row.le.1.and.d_col.le.1) .or. 
+     > (d_row.eq.0.and.d_col.le.2) ) then
 *
 *-------------------Assign them to the same current cluster
                     hcluster_hit(jhit)=hcluster_hit(ihit)
@@ -204,7 +205,7 @@
         if(hcluster_et(nc).gt.0.) then
           hcluster_xc(nc)=hcluster_xc(nc)/hcluster_et(nc)
         else
-          hcluster_xc(nc)= -1.0         ! Set fraction negative for bad et
+          hcluster_xc(nc)= -1000.0         ! Set fraction negative for bad et
         endif
       enddo
 *

--- a/HTRACKING/h_tracks_cal.f
+++ b/HTRACKING/h_tracks_cal.f
@@ -125,14 +125,14 @@
 *----------If inside fv (or no test), Search for a cluster matching this track
 *
         if( (hcal_fv_test.ne.0.and.track_in_fv) .or. hcal_fv_test.eq.0) then
-
           if(hnclusters_cal.gt.0) then
 !! TH - Initialize minimum distance between track and cluster location.
             t_minx = 99999
-            t_nt = 1
-            t_nc = 1
+            t_nt = -1
+            t_nc = -1
             do nc=1,hnclusters_cal
 !! TH - Distance to match track with cluster
+               if (hcluster_xc(nc) .ne. -1000.) then
               delta_x=abs(xf-hcluster_xc(nc))
               if(delta_x.le.(0.5*hcal_block_xsize + hcal_slop)) then
 !! TH - Check the deviation distance for each track for each cluster. If 
@@ -148,8 +148,9 @@
                  endif
                  hntracks_cal      =hntracks_cal+1
               endif                     !End ... if matched
+              endif ! 
             enddo                       !End loop over clusters
-            hcluster_track(t_nt)=t_nc   !Track matches cluster #nc with min deviation
+            if ( t_nt .ge. 1) hcluster_track(t_nt)=t_nc   !Track matches cluster #nc with min deviation
           endif                         !End ... if number of clusters > 0
         endif                           
       enddo                             !End loop over detector tracks


### PR DESCRIPTION
Made two changes to HTRACKING/h_clusters_cal.f
1) If hcluster_et is zero changed the setting of hcluster_xc from -1 to -1000.0 . For some events the -1
    become the closest to the track and gets matched to a track. Setting to -1000 avoids this problem.  In HCANA,  THcShower.cxx sets cluster xc = -75 to avoid this problem. 
2) The code made clusters for difference in row and column number less than or equal to one. This meant that if one column in the same row did not have energy > 0  but the other columns in that row did have energy >0, then there would be two clusters in the same row. Decide to change so that the condition for adding to a cluster is (difference in row and col <=1) OR ( difference in row = 0 and diff in col <=2). In HCANA, this has to be added to ThCShower.h 

In HTRACKING/h_tracks_cal.f changed logic so that if track did not hit a calorimeter cluster than that track had the array hcluster_track , which identifies which cluster number  goes with the track, is left set to -1 which means no cluster for the track. Previously if no calorimeter cluster matched a track, the code would default to set track number 1 to cluster number 1 which makes no sense.  In HCANA this problem didn't exist, since it used a different algorithm for matching a track with cluster.
