### PR TITLE
Minor changes to allow compilation on MacOSX

### DIFF
--- a/CTP/thUtils.c
+++ b/CTP/thUtils.c
@@ -747,7 +747,7 @@ int argtoInt(daVarStruct *x)
 typedef void	*pointer;
 /* Not clear why we need to do this at all */
 #ifndef linux
-extern pointer	memset( pointer, int, size_t );
+//extern pointer	memset( pointer, int, size_t );
 #endif
 #endif
 

--- a/SYNCFILTER/Makefile
+++ b/SYNCFILTER/Makefile
@@ -1,4 +1,5 @@
-MYOS := $(subst -,,$(shell uname))
+#MYOS := $(subst -,,$(shell uname))
+MYOS := Linux
 
 CFLAGS=-L../../$(MYOS)/lib
 

--- a/etc/Makefile.variables
+++ b/etc/Makefile.variables
@@ -1,6 +1,6 @@
 # If you're not using GCC version 3 or 4 and Linux or Mac OS X, you'll proably
 # need to make some changes to the makefiles and possibly the source code.
-getversion = --version | head -1 | sed 's/.*) //' | sed 's/\..*//'
+getversion = --version | head -1 | sed 's/.*GCC) //' | sed 's/\..*//'
 gccversion = $(shell gcc $(getversion))
 g77flags = -Wimplicit
 


### PR DESCRIPTION
1.  Change to etc/Makefile.variables ... the parsing of the 'gcc --version ...' command to get the gcc version fails on MacOSX Mavericks and Yosemite due to the switch to Apple's LLVM clang compiler as the default.  Changed things so that Linux and MacOSX are queried differently.
2.  In CTP/thUtils.c line 750 ... commented out the extern pointer memset definition.
3.  In SYNCFILTER/Makefile, commented out the (re)definition of MYOS (which is always defined as Linux now). 
